### PR TITLE
Handling 400 in statistic api call

### DIFF
--- a/tap_xtm/streams.py
+++ b/tap_xtm/streams.py
@@ -206,6 +206,11 @@ class ProjectStats(TapXtmStream):
                     f"Jobs do not exist in the project {context.get('project_id')}. Skipping."
                 )
                 return []
+            elif "400 Client Error" in str(e):
+                self.logger.warning(
+                    f"Failed to process the 'statistics' API endpoint for project ID {context.get('project_id')}. Skipping."
+                )
+                return []
             else:
                 raise
 


### PR DESCRIPTION
This pull request includes a small update to the `request_records` method in `tap_xtm/streams.py`. The change adds a new condition to handle "400 Client Error" responses gracefully by logging a warning and skipping processing for the affected project ID.