### PR TITLE
Include xtm edc endpoints

### DIFF
--- a/tap_xtm/streams.py
+++ b/tap_xtm/streams.py
@@ -1,16 +1,15 @@
 """Stream class for tap-xtm."""
 
-import base64
-import json
-from typing import Dict, Optional, Any, Iterable
+import re
+import random
+import requests
+
 from pathlib import Path
-from singer_sdk import typing
-from functools import cached_property
 from singer_sdk import typing as th
 from singer_sdk.streams import RESTStream
-from singer_sdk.authenticators import SimpleAuthenticator
 from singer_sdk.exceptions import FatalAPIError
-import requests
+from typing import Dict, Optional, Any, Iterable
+from singer_sdk.authenticators import SimpleAuthenticator
 
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
@@ -283,3 +282,67 @@ class ProjectMetrics(TapXtmStream):
                 return []
             else:
                 raise
+
+
+class ProjectStatsEDC(TapXtmStream):
+    name = "projectstatsedc"
+    parent_stream_type = Projects
+    path = "/projects/{project_id}/statistics/edc"  # API endpoint after base_url
+    records_jsonpath = "$[*]"  # https://jsonpath.com Use requests response json to identify the json path
+    primary_keys = ["project_id"]
+    replication_key = None
+
+    def backoff(self, retry_count):
+        base = min(2**retry_count, 30)  # exponential backoff capped at 30s
+        jitter = random.uniform(0, 1)
+        return base + jitter
+
+    def get_url_params(self, context: dict, next_page_token: Optional[Any]) -> dict:
+        return {
+            "fetchLevel": "JOBS",
+            "statisticsFetchType": "DELETED",
+            "edcScoreType": "AVERAGE",
+        }
+
+    schema = th.PropertiesList(
+        th.Property("project_id", th.NumberType),
+        th.Property("fetchLevel", th.StringType),
+        th.Property("statisticsFetchType", th.StringType),
+        th.Property("edcScoreType", th.StringType),
+        th.Property("score", th.NumberType),
+        th.Property(
+            "jobs",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("id", th.NumberType),
+                    th.Property("score", th.NumberType),
+                )
+            ),
+        ),
+    ).to_dict()
+
+    def post_process(self, row: dict, context: Optional[dict]) -> dict:
+        row["project_id"] = context["project_id"]
+        row["fetchLevel"] = "JOBS"
+        row["statisticsFetchType"] = "DELETED"
+        row["edcScoreType"] = "AVERAGE"
+        return row
+
+    def request_records(self, context: Optional[dict]) -> Iterable[dict]:
+        try:
+            yield from super().request_records(context)
+        except FatalAPIError as e:
+            # Fallback: try to parse from error message string (last resort)
+
+            match = re.search(r"(\d{3}) Client Error", str(e))
+            if match:
+                status_code = int(match.group(1))
+
+            # Handle 4xx client errors generically
+            if status_code and 400 <= status_code < 500:
+                self.logger.warning(
+                    f"Client error {status_code} for project {context.get('project_id')}. Skipping."
+                )
+                return []
+            # For other errors (5xx server errors or unknown), re-raise
+            raise

--- a/tap_xtm/tap.py
+++ b/tap_xtm/tap.py
@@ -1,9 +1,6 @@
 """xtm tap class."""
 
-from pathlib import Path
 from typing import List
-import logging
-import click
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th
 
@@ -12,11 +9,12 @@ from tap_xtm.streams import (
     ProjectDetails,
     ProjectStats,
     ProjectMetrics,
+    ProjectStatsEDC,
 )
 
 PLUGIN_NAME = "tap-xtm"
 
-STREAM_TYPES = [Projects, ProjectDetails, ProjectStats, ProjectMetrics]
+STREAM_TYPES = [Projects, ProjectDetails, ProjectStats, ProjectMetrics, ProjectStatsEDC]
 
 
 class TapXtm(Tap):


### PR DESCRIPTION
This pull request introduces a new stream for extracting EDC statistics from project data, refactors imports for clarity, and updates the tap configuration to include the new stream. The main focus is on extending functionality to support EDC statistics retrieval and handling API errors gracefully.

**New EDC Statistics Stream:**

* Added a new stream class `ProjectStatsEDC` in `tap_xtm/streams.py` to fetch EDC statistics for projects, including schema definition and custom error handling for API client errors.
* Implemented exponential backoff with jitter in `ProjectStatsEDC` to improve robustness against transient API failures.

**Codebase Maintenance:**

* Refactored import statements in `tap_xtm/streams.py` and `tap_xtm/tap.py` for better readability and removed unused imports. [[1]](diffhunk://#diff-ab87d59fdaff137eb66ebf8a57858050e5bddf99ab817330115fbe5cbbcd837bL3-R12) [[2]](diffhunk://#diff-27aeb43e95fbe6c29aef455cb6612974a529bac5ad0d455e57eb501c7cc25ffcL3-L6)

**Tap Configuration Update:**

* Registered the new `ProjectStatsEDC` stream in the tap's `STREAM_TYPES` list in `tap_xtm/tap.py`, enabling it as part of the extract process.